### PR TITLE
Add custom layer example

### DIFF
--- a/custom-layer-example/README.md
+++ b/custom-layer-example/README.md
@@ -1,0 +1,7 @@
+Demo Composite Layer
+===================
+
+This directory provides an example of the minimum code necessary to write a custom
+layer for use in pydeck.
+
+To create the bundle that you can pass to pydeck via a URI, run `webpack` in this directory.

--- a/custom-layer-example/demo-composite-layer.js
+++ b/custom-layer-example/demo-composite-layer.js
@@ -1,0 +1,8 @@
+import { CompositeLayer } from "@deck.gl/core";
+import { ScatterplotLayer } from "@deck.gl/layers";
+
+export class DemoCompositeLayer extends CompositeLayer {
+  renderLayers() {
+    return new ScatterplotLayer(this.props);
+  }
+}

--- a/custom-layer-example/index.js
+++ b/custom-layer-example/index.js
@@ -1,0 +1,1 @@
+export { DemoCompositeLayer } from "./demo-composite-layer";

--- a/custom-layer-example/package.json
+++ b/custom-layer-example/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "TagmapLayer",
+    "version": "0.0.0",
+    "main": "index.js",
+    "private": true,
+    "dependencies": {
+        "@deck.gl/core": "^8.0.12",
+        "@deck.gl/layers": "^8.0.12"
+    },
+    "devDependencies": {
+        "webpack": "^4.41.6",
+        "webpack-cli": "^3.3.11"
+    }
+}

--- a/custom-layer-example/webpack.config.js
+++ b/custom-layer-example/webpack.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  output: {
+    libraryTarget: "umd",
+    filename: "bundle.js",
+    library: "CustomLayerLibrary"
+  },
+  entry: {
+    main: "./index.js"
+  },
+  externals: {
+    "@deck.gl/layers": {
+      commonjs: "deck",
+      commonjs2: "deck",
+      root: "deck"
+    },
+    "@deck.gl/core": {
+      root: "deck",
+      commonjs: "deck",
+      commonjs2: "deck"
+    }
+  }
+};


### PR DESCRIPTION
Pydeck as of 0.3.0 supports custom layers ([PR](https://github.com/uber/deck.gl/pull/4267/files)), but we don't yet have an example of how to write a custom layer's JS bundle. This PR solves that issue.